### PR TITLE
Update typo in NAMESPACE

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -3,7 +3,7 @@ useDynLib(mvstpp, .registration=TRUE)
 export("FMvariogram")
 export("gsp")
 export("gte")
-export("stdccpp")
+export("stdcpp")
 export("sthpcpp")
 
 import(splancs)


### PR DESCRIPTION
This fixes issue #2 regarding failure to export ```stdccpp``` which exists as ```stdcpp.R```. This was preventing the installation of the entire package for all users. Can't wait to use it now!